### PR TITLE
docs: fix README local dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ yarn
 yarn start
 ```
 
-The open http://localhost:8080/ in your browser and drop `lcov.info` file into the dropzone.
+Then open http://localhost:8080/ in your browser and drop `lcov.info` file into the dropzone.
 
 ![viewer](https://user-images.githubusercontent.com/1678896/139163904-5f845791-2af5-4cdd-b044-98406b2963b7.gif)


### PR DESCRIPTION
## Summary
- fix Local Development Setup instructions in README to say "Then open http://localhost:8080/"

## Testing
- `yarn test` *(fails to write coverage reports: Cannot find module '/workspace/lcov-viewer/node_modules/@lcov-viewer/istanbul-report/lib/index.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a119068abc832e9f75b89980c48b44